### PR TITLE
Correct in bug in the property changed event

### DIFF
--- a/bluez_peripheral/gatt/characteristic.py
+++ b/bluez_peripheral/gatt/characteristic.py
@@ -202,7 +202,7 @@ class characteristic(ServiceInterface):
             new_value (bytes): The new value of the property to send to any subscribers.
         """
         if self._notify:
-            self.emit_properties_changed({"Value": new_value}, ["Value"])
+            self.emit_properties_changed({"Value": new_value}, [])
 
     # Decorators
     def setter(

--- a/tests/gatt/test_characteristic.py
+++ b/tests/gatt/test_characteristic.py
@@ -187,7 +187,6 @@ class TestCharacteristic(IsolatedAsyncioTestCase):
                 assert interface == "org.bluez.GattCharacteristic1"
                 assert len(values) == 1
                 assert values["Value"].value.decode("utf-8") == "Test Notify Value"
-                assert "Value" in invalid_props
                 property_changed.set()
                 
 


### PR DESCRIPTION
Hi,

This is a simple bugfix for the parameters sent with the PropertiesChanged signal. According to the [DBus specs](https://dbus.freedesktop.org/doc/dbus-specification.html), the last parameter of PropertiesChanged is "invalidated_properties", which "is an array of properties that changed but the value is not conveyed".
Since we provide the value in the "changed_properties" parameter, we don't need to specify it.

It is a small change, but it avoids bluetoothd from crashing with the current version.