### PR TITLE
Automate build versioning

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,6 +1,6 @@
 name: Test Python Package
 
-on: [ push, pull_request, workflow_dispatch ]
+on: [ pull_request, workflow_dispatch ]
 
 jobs:
   test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [build-system]
 requires = [
     "setuptools>=42",
-    "wheel"
+    "wheel",
+    "setuptools_scm>=6.2"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = bluez_peripheral
-version = 0.1.2
 author = SpaceCheese
 description = A library for building BLE peripherals using GATT and bluez
 long_description = file: README.md


### PR DESCRIPTION
Removes the version specifier from setup.cfg in favor of automated versioning based on git tags. Also stops testing workflow from running on push.