### PR TITLE
UUID128 Adverts

### DIFF
--- a/bluez_peripheral/advert.py
+++ b/bluez_peripheral/advert.py
@@ -141,7 +141,9 @@ class Advertisement(ServiceInterface):
 
     @dbus_property(PropertyAccess.READ)
     def ServiceUUIDs(self) -> "as":  # type: ignore
-        return [id.uuid16 for id in self._serviceUUIDs]
+        return [
+            id.uuid16 if not id.uuid16 is None else str(id) for id in self._serviceUUIDs
+        ]
 
     @dbus_property(PropertyAccess.READ)
     def LocalName(self) -> "s":  # type: ignore

--- a/bluez_peripheral/advert.py
+++ b/bluez_peripheral/advert.py
@@ -73,7 +73,7 @@ class Advertisement(ServiceInterface):
         self._type = packet_type
         # Convert any string uuids to uuid16.
         self._serviceUUIDs = [
-            uuid if type(uuid) is BTUUID else BTUUID.from_uuid16(uuid)
+            uuid if type(uuid) is BTUUID else BTUUID.from_uuid16_128(uuid)
             for uuid in serviceUUIDs
         ]
         self._localName = localName

--- a/bluez_peripheral/gatt/characteristic.py
+++ b/bluez_peripheral/gatt/characteristic.py
@@ -181,7 +181,7 @@ class characteristic(ServiceInterface):
         flags: CharacteristicFlags = CharacteristicFlags.READ,
     ):
         if uuid is str:
-            uuid = BTUUID.from_uuid16(uuid)
+            uuid = BTUUID.from_uuid16_128(uuid)
         self.uuid = uuid
         self.getter_func = None
         self.setter_func = None

--- a/bluez_peripheral/gatt/descriptor.py
+++ b/bluez_peripheral/gatt/descriptor.py
@@ -119,7 +119,7 @@ class descriptor(ServiceInterface):
         flags: DescriptorFlags = DescriptorFlags.READ,
     ):
         if uuid is str:
-            uuid = UUID.from_uuid16(uuid)
+            uuid = UUID.from_uuid16_128(uuid)
         self.uuid = uuid
         self.getter_func = None
         self.setter_func = None

--- a/bluez_peripheral/gatt/service.py
+++ b/bluez_peripheral/gatt/service.py
@@ -41,7 +41,7 @@ class Service(ServiceInterface):
         includes: Collection["Service"] = [],
     ):
         # Make sure uuid is a uuid16.
-        self._uuid = uuid if type(uuid) is UUID else UUID.from_uuid16(uuid)
+        self._uuid = uuid if type(uuid) is UUID else UUID.from_uuid16_128(uuid)
         self._primary = primary
         self._characteristics = []
         self._path = None

--- a/bluez_peripheral/uuid.py
+++ b/bluez_peripheral/uuid.py
@@ -68,18 +68,15 @@ class BTUUID(UUID):
             return uuid
 
     @property
-    def uuid16(self) -> str:
+    def uuid16(self) -> Union[str, None]:
         """Converts the UUID16 to a 4 digit string representation.
 
-        Raises:
-            ValueError: Raised if this UUID is not a valid UUID16.
-
         Returns:
-            str: The UUID representation.
+            Union[str, None]: The UUID representation or None if self is not a valid UUID16.
         """
         match = self._UUID16_UUID128_RE.search(str(self))
 
         if not match:
-            raise ValueError("self is not a uuid16")
+            return None
 
         return match.group(1)

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,10 @@
+# Running Unit Tests
+Install the test dependencies
+```bash
+pip install -r requirements.txt
+```
+Add the dbus config to allow the test process access to the bluetooth daemon.
+> This has serious security implications so only do this if you know what you are doing.
+```bash
+sudo cp com.spacecheese.test.conf /etc/dbus-1/system.d
+```

--- a/tests/gatt/test_characteristic.py
+++ b/tests/gatt/test_characteristic.py
@@ -1,7 +1,7 @@
 from bluez_peripheral.gatt.descriptor import descriptor
 from unittest import IsolatedAsyncioTestCase
 from threading import Event
-from ..util import *
+from tests.util import *
 import re
 
 from bluez_peripheral.util import get_message_bus

--- a/tests/test_advert.py
+++ b/tests/test_advert.py
@@ -74,6 +74,31 @@ class TestAdvert(IsolatedAsyncioTestCase):
         adapter = MockAdapter(inspector)
         await advert.register(self._bus_manager.bus, adapter)
 
+    async def test_uuid128(self):
+        advert = Advertisement(
+            "Improv Test",
+            [BTUUID("00467768-6228-2272-4663-277478268000")],
+            0x0340,
+            2,
+        )
+
+        async def inspector(path):
+            introspection = await self._client_bus.introspect(
+                self._bus_manager.name, path
+            )
+            proxy_object = self._client_bus.get_proxy_object(
+                self._bus_manager.name, path, introspection
+            )
+            interface = proxy_object.get_interface("org.bluez.LEAdvertisement1")
+
+            assert [id.lower() for id in await interface.get_service_uui_ds()] == [
+                "00467768-6228-2272-4663-277478268000",
+            ]
+            print(await interface.get_service_uui_ds())
+
+        adapter = MockAdapter(inspector)
+        await advert.register(self._bus_manager.bus, adapter)
+
     async def test_real(self):
         await bluez_available_or_skip(self._client_bus)
         adapter = await get_first_adapter_or_skip(self._client_bus)

--- a/tests/test_advert.py
+++ b/tests/test_advert.py
@@ -1,7 +1,7 @@
 from unittest import IsolatedAsyncioTestCase
 from unittest.case import SkipTest
 
-from .util import *
+from tests.util import *
 
 from bluez_peripheral.util import get_message_bus
 from bluez_peripheral.advert import Advertisement, PacketType, AdvertisingIncludes

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,6 +1,6 @@
 from unittest import IsolatedAsyncioTestCase
 
-from .util import *
+from tests.util import *
 
 from bluez_peripheral.util import get_message_bus
 from bluez_peripheral.agent import AgentCapability, BaseAgent

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,6 @@
 from unittest import IsolatedAsyncioTestCase
 
-from .util import *
+from tests.util import *
 
 from bluez_peripheral.util import *
 


### PR DESCRIPTION
Fixes #7.
- Allows UUID128 service IDs to be used in adverts.
- Adds testing for UUID128 advertising support.
- Allows both UUID16s and UUID128s to be converted from strings.
- Fixes some minor issues with testing setup and adds a testing README.