### PR TITLE
Fixed checking if uuid is type of string

### DIFF
--- a/bluez_peripheral/gatt/characteristic.py
+++ b/bluez_peripheral/gatt/characteristic.py
@@ -180,7 +180,7 @@ class characteristic(ServiceInterface):
         uuid: Union[BTUUID, str],
         flags: CharacteristicFlags = CharacteristicFlags.READ,
     ):
-        if uuid is str:
+        if type(uuid) is str:
             uuid = BTUUID.from_uuid16_128(uuid)
         self.uuid = uuid
         self.getter_func = None

--- a/bluez_peripheral/gatt/descriptor.py
+++ b/bluez_peripheral/gatt/descriptor.py
@@ -118,7 +118,7 @@ class descriptor(ServiceInterface):
         characteristic: "characteristic",  # type: ignore
         flags: DescriptorFlags = DescriptorFlags.READ,
     ):
-        if uuid is str:
+        if type(uuid) is str:
             uuid = UUID.from_uuid16_128(uuid)
         self.uuid = uuid
         self.getter_func = None


### PR DESCRIPTION
Fixes two checks in characteristic and descriptor for checking if the uuid variable is of type string.