### PR TITLE
Advertising unexport

### DIFF
--- a/bluez_peripheral/advert.py
+++ b/bluez_peripheral/advert.py
@@ -63,14 +63,14 @@ class Advertisement(ServiceInterface):
         appearance: Union[int, bytes],
         timeout: int,
         discoverable: bool = True,
-        packet_type: PacketType = PacketType.PERIPHERAL,
+        packetType: PacketType = PacketType.PERIPHERAL,
         manufacturerData: Dict[int, bytes] = {},
         solicitUUIDs: Collection[BTUUID] = [],
         serviceData: Dict[str, bytes] = {},
         includes: AdvertisingIncludes = AdvertisingIncludes.NONE,
         duration: int = 2,
     ):
-        self._type = packet_type
+        self._type = packetType
         # Convert any string uuids to uuid16.
         self._serviceUUIDs = [
             uuid if type(uuid) is BTUUID else BTUUID.from_uuid16_128(uuid)

--- a/tests/test_advert.py
+++ b/tests/test_advert.py
@@ -22,7 +22,7 @@ class TestAdvert(IsolatedAsyncioTestCase):
             ["180A", "180D"],
             0x0340,
             2,
-            packet_type=PacketType.PERIPHERAL,
+            packetType=PacketType.PERIPHERAL,
             includes=AdvertisingIncludes.TX_POWER,
         )
 
@@ -56,7 +56,7 @@ class TestAdvert(IsolatedAsyncioTestCase):
             ["180A", "180D"],
             0x0340,
             2,
-            packet_type=PacketType.PERIPHERAL,
+            packetType=PacketType.PERIPHERAL,
             includes=AdvertisingIncludes.NONE,
         )
 


### PR DESCRIPTION
- Rename the advertisement packet_type parameter to packetType for consistency
- Advertisements will now:
  - Be allocated unique bus paths depending on how many advertisements have been previously created.
  - Will not be unexported from the bus until after the Release function is called.
  - Provide a Release callback.
  
TODO:
- ~~Test updated advert behavior including the Release callback~~ (TODO in a future PR)