### PR TITLE
Fix typo and remove star imports in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,5 +108,5 @@ async def main():
 if __name__ == "__main__":
     asyncio.run(main())
 ```
-To communicate with bluez the default dbus configuration requires that you be in the bluetooth user group (eg. `sudo useradd -aG bluetooth spacecheese`).
+To communicate with bluez the default dbus configuration requires that you be in the bluetooth user group (eg. `sudo usermod -aG bluetooth $USER`).
 For more examples please read the [documentation](https://bluez-peripheral.readthedocs.io/en/latest/).

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ class HeartRateService(Service):
 ```
 Bluez interfaces with bluez-peripheral using dbus for inter-process communication. For Bluez to start offering your service it needs to be registered on this bus. Additionally if you want devices to pair with your device you need to register an agent to decide how pairing should be completed. Finally you also need to advertise the service to nearby devices.
 ```python
-from bluez_peripheral.util import *
+from bluez_peripheral.util import Adapter, get_message_bus
 from bluez_peripheral.advert import Advertisement
 from bluez_peripheral.agent import NoIoAgent
 import asyncio

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -38,7 +38,7 @@ You can use these decorators the same way as the built-in `property class <https
       # In Python 3.9+:
       # @characteristic("BEF1", CharFlags.WRITE).setter
       # Define a characteristic writing function like so.
-      @my_readonly_characteristic.setter
+      @my_writeonly_characteristic.setter
       def my_writeonly_characteristic(self, value, options):
          # Your characteristics will need to handle bytes.
          self._some_value = value

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -71,14 +71,14 @@ You need to advertise your service to allow other devices to connect to it.
 
 .. code-block:: python
 
-   from bluez_peripheral.advert import Advertisment
+   from bluez_peripheral.advert import Advertisement
 
    my_service_ids = ["BEEF"] # The services that we're advertising.
    my_appearance = 0 # The appearance of my service. 
    # See https://specificationrefs.bluetooth.com/assigned-values/Appearance%20Values.pdf
    my_timeout = 60 # Advert should last 60 seconds before ending (assuming other local 
    # services aren't being advertised).
-   advert = Advertisment("My Device Name", my_service_ids, my_appearance, my_timeout)
+   advert = Advertisement("My Device Name", my_service_ids, my_appearance, my_timeout)
 
 
 At this point you'll be be able to connect to your device using a bluetooth tester 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -56,8 +56,7 @@ Once you've defined your service you need to add it to a service collection whic
 
 .. code-block:: python
 
-   from bluez_peripheral.gatt.service import ServiceCollection
-   from ble.util import *
+   from ble.util import get_message_bus
 
    # This needs running in an awaitable context.
    bus = await get_message_bus()

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -56,7 +56,7 @@ Once you've defined your service you need to add it to a service collection whic
 
 .. code-block:: python
 
-   from ble.util import get_message_bus
+   from bluez_peripheral.util import get_message_bus
 
    # This needs running in an awaitable context.
    bus = await get_message_bus()


### PR DESCRIPTION
Hi!
I ran into some import issues while trying to run the examples in the README and the docs. Here's a fix; I took the liberty of removing the star imports in the examples to make clear what is being imported.